### PR TITLE
Add 3 second delay before linking machines and nodes

### DIFF
--- a/add-machine-ips.sh
+++ b/add-machine-ips.sh
@@ -13,5 +13,6 @@ for node in $(oc --config ocp/auth/kubeconfig get nodes -o template --template='
     if [[ "$machine_name" == *"worker"* ]]; then
         machine_name=$(oc --config ocp/auth/kubeconfig get machines -n openshift-machine-api | grep $node_name | cut -f1 -d' ')
     fi
+    sleep 3
     $SCRIPTDIR/link-machine-and-node.sh "$machine_name" "$node"
 done


### PR DESCRIPTION
The preceeding steps leading up to running link-machine-and-node.sh
via add-machine-ips.sh might create a condition on slower systems
or systems with resource contention to not start the machine API
soon enough for the link-machine-and-node.sh steps to succesfully
interact with an API that hasn't yet come up.  The result of this
failure is "Failed connect to localhost:8001; Connection refused".